### PR TITLE
--append_numbers flag to append numbers to part names in library

### DIFF
--- a/JLC2KiCadLib/JLC2KiCadLib.py
+++ b/JLC2KiCadLib/JLC2KiCadLib.py
@@ -46,6 +46,7 @@ def add_component(component_id, args):
             library_name=args.schematic_lib,
             output_dir=args.output_dir,
             component_id=component_id,
+            append_numbers=args.append_numbers,
         )
 
 
@@ -107,6 +108,13 @@ def main():
         type=str,
         default="footprint",
         help='set footprint library name,  default is "footprint"',
+    )
+
+    parser.add_argument(
+        "--append_numbers",
+        dest="append_numbers",
+        action="store_true",
+        help="use --append_numbers if you want to append part numbers to names",
     )
 
     parser.add_argument(

--- a/JLC2KiCadLib/footprint/footprint.py
+++ b/JLC2KiCadLib/footprint/footprint.py
@@ -113,7 +113,7 @@ def create_footprint(
 
 def get_footprint_info(footprint_component_uuid):
 
-    # fetch the compoennt data for easyeda library
+    # fetch the component data for easyeda library
     response = requests.get(
         f"https://easyeda.com/api/components/{footprint_component_uuid}"
     )

--- a/JLC2KiCadLib/schematic/schematic.py
+++ b/JLC2KiCadLib/schematic/schematic.py
@@ -55,7 +55,6 @@ def create_schematic(
             .replace(" ", "_")
             .replace(".", "_")
         )
-        component_description = data["result"]["description"]
 
         if not ComponentName:
             ComponentNameValue = component_title

--- a/JLC2KiCadLib/schematic/schematic.py
+++ b/JLC2KiCadLib/schematic/schematic.py
@@ -33,6 +33,7 @@ def create_schematic(
     kicad_schematic = kicad_schematic()
 
     ComponentName = ""
+    ComponentNameValue = ""
     for component_uuid in schematic_component_uuid:
 
         response = requests.get(f"https://easyeda.com/api/components/{component_uuid}")
@@ -56,6 +57,7 @@ def create_schematic(
         )
 
         if not ComponentName:
+            ComponentNameValue = component_title
             if append_numbers:
                 component_title += "_" + component_id
             ComponentName = component_title
@@ -88,17 +90,20 @@ def create_schematic(
     (property "Reference" "{symmbolic_prefix}" (id 0) (at 0 1.27 0)
       (effects (font (size 1.27 1.27)))
     )
-    (property "Value" "{ComponentName}" (id 1) (at 0 -2.54 0)
-      (effects (font (size 1.27 1.27)))
+    (property "Value" "{ComponentName}" (id 1) (at 0 -1.27 0)
+      (effects (font (size 1.27 1.27)) {"" if not append_numbers else "hide"})
     )
-    (property "Footprint" "{footprint_name}" (id 2) (at 0 -10.16 0)
+    (property "Footprint" "{footprint_name}" (id 2) (at 0 -13.97 0)
       (effects (font (size 1.27 1.27) italic) hide)
     )
-    (property "Datasheet" "{datasheet_link}" (id 3) (at -2.286 0.127 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
+    (property "Datasheet" "{datasheet_link}" (id 3) (at 0 -16.51 0)
+      (effects (font (size 1.27 1.27)) hide)
     )
-    (property "LCSC" "{component_id}" (id 4) (at 0 0 0)
-      (effects (font (size 1.27 1.27)))
+    (property "Name" "{ComponentNameValue}" (id 4) (at 0 -1.27 0)
+      (effects (font (size 1.27 1.27)) {"" if append_numbers else "hide"})
+    )
+    (property "LCSC" "{component_id}" (id 5) (at 0 -6.35 0)
+      (effects (font (size 1.27 1.27)) hide)
     ){kicad_schematic.drawing}
   )"""
 

--- a/JLC2KiCadLib/schematic/schematic.py
+++ b/JLC2KiCadLib/schematic/schematic.py
@@ -23,6 +23,7 @@ def create_schematic(
     library_name,
     output_dir,
     component_id,
+    append_numbers,
 ):
     class kicad_schematic:
         drawing = ""
@@ -55,6 +56,8 @@ def create_schematic(
         )
 
         if not ComponentName:
+            if append_numbers:
+                component_title += "_" + component_id
             ComponentName = component_title
             component_title += "_0"
         if (

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ options:
                         set schematic library name, default is "default_lib"
   -footprint_lib FOOTPRINT_LIB
                         set footprint library name, default is "footprint"
+  --append_numbers      use --append_numbers if you want to append part numbers to names
   -logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         set logging level. If DEBUG is used, the debug logs are only written in the log file if the option --log_file is set
   --log_file            use --log_file if you want logs to be written in a file


### PR DESCRIPTION
Hello,
I have added --append_numbers flag to append part numbers to names in the library. That helps a little bit when searching in the library, because of working on part numbers. I have changed the LCSC number property to be hidden by default because IMHO it's not really needed straight away on the schematic. Also, I have added a Name property that will keep the name of the component without the LCSC part number.