### PR TITLE
add --skip_existing flag to skip existing symbols/footprints

### DIFF
--- a/JLC2KiCadLib/JLC2KiCadLib.py
+++ b/JLC2KiCadLib/JLC2KiCadLib.py
@@ -33,6 +33,7 @@ def add_component(component_id, args):
             footprint_lib=args.footprint_lib,
             output_dir=args.output_dir,
             model_base_variable=args.model_base_variable,
+            skip_existing=args.skip_existing,
         )
     else:
         _, datasheet_link, _ = get_footprint_info(footprint_component_uuid)
@@ -46,6 +47,7 @@ def add_component(component_id, args):
             library_name=args.schematic_lib,
             output_dir=args.output_dir,
             component_id=component_id,
+            skip_existing=args.skip_existing,
         )
 
 
@@ -125,6 +127,15 @@ def main():
         action="store_true",
         help="use --log_file if you want logs to be written in a file",
     )
+
+
+    parser.add_argument( # argument for skip already existing files and schematic symbols
+        "--skip_existing",
+        dest="skip_existing",
+        action="store_true",
+        help="use --skip_existing if you want to skip already existing files and schematic symbols",
+    )
+
 
     args = parser.parse_args()
 

--- a/JLC2KiCadLib/footprint/footprint.py
+++ b/JLC2KiCadLib/footprint/footprint.py
@@ -13,12 +13,19 @@ def create_footprint(
     footprint_lib,
     output_dir,
     model_base_variable,
+    skip_existing
 ):
     logging.info("creating footprint ...")
 
     footprint_name, datasheet_link, footprint_shape = get_footprint_info(
         footprint_component_uuid
     )
+
+    if skip_existing:
+        # check if footprint already exists:
+        if os.path.isfile(os.path.join(output_dir, footprint_lib, footprint_name + ".kicad_mod")):
+            logging.info(f"Footprint {footprint_name} already exists, skipping.")
+            return f"{footprint_lib}:{footprint_name}", datasheet_link
 
     # init kicad footprint
     kicad_mod = Footprint(f'"{footprint_name}"')

--- a/JLC2KiCadLib/schematic/schematic.py
+++ b/JLC2KiCadLib/schematic/schematic.py
@@ -30,6 +30,7 @@ def create_schematic(
     library_name,
     output_dir,
     component_id,
+    skip_existing
 ):
     class kicad_schematic:
         drawing = ""
@@ -124,13 +125,13 @@ def create_schematic(
         os.makedirs(f"{output_dir}/Schematic")
 
     if os.path.exists(filename):
-        update_library(library_name, ComponentName, template_lib_component, output_dir)
+        update_library(library_name, ComponentName, template_lib_component, output_dir, skip_existing)
     else:
         with open(filename, "w") as f:
             logging.info(f"writing in {filename} file")
             f.write(template_lib_header)
             f.write(template_lib_footer)
-        update_library(library_name, ComponentName, template_lib_component, output_dir)
+        update_library(library_name, ComponentName, template_lib_component, output_dir, skip_existing)
 
 
 def get_type_values_properties(start_index, component_types_values):
@@ -144,7 +145,7 @@ def get_type_values_properties(start_index, component_types_values):
     )
 
 
-def update_library(library_name, component_title, template_lib_component, output_dir):
+def update_library(library_name, component_title, template_lib_component, output_dir, skip_existing):
     """
     if component is already in library,
     the library will be updated,
@@ -157,6 +158,9 @@ def update_library(library_name, component_title, template_lib_component, output
         file_content = lib_file.read().decode()
 
         if f'symbol "{component_title}"' in file_content:
+            if skip_existing:
+                logging.info(f"component {component_title} already in schematics library, skipping")
+                return
             # use regex to find the old component template in the file and replace it with the new one
             logging.info(
                 f"found component already in {library_name}, updating {library_name}"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ options:
   -logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         set logging level. If DEBUG is used, the debug logs are only written in the log file if the option --log_file is set
   --log_file            use --log_file if you want logs to be written in a file
+  --skip_existing       use --skip_existing if you want to skip the creation of a symbol/footprint if they already exist
 ```
 
 Example usage : `JLC2KiCadLib C1337258 C24112 -dir My_lib -schematic_lib My_Schematic_lib`


### PR DESCRIPTION
Adds a --skip_existing flag for skipping schematic symbols that already exist in the library and footprint files that already exist in the footprint folder.

I find this feature useful if I have edited a footprint and don't want to overwrite my changes accidentally. 

**This flag will also skip creating  3d file if footprint file exists**

