### PR TITLE
Add check for oval pad holes in rectangle TH pads

### DIFF
--- a/JLC2KiCadLib/footprint/footprint_handlers.py
+++ b/JLC2KiCadLib/footprint/footprint_handlers.py
@@ -125,7 +125,7 @@ def h_PAD(data, kicad_mod, footprint_info):
         if data[11] == 0:
             drill_size = data[7] * 2
         elif (data[7] * 2 < data[11]) ^ (
-            size[0] > size[1]
+                size[0] > size[1]
         ):  # invert the orientation of the drill hole if not in the same orientation as the pad shape
             drill_size = [data[7] * 2, data[11]]
         else:
@@ -135,6 +135,11 @@ def h_PAD(data, kicad_mod, footprint_info):
         pad_type = Pad.TYPE_THT
         pad_layer = Pad.LAYERS_THT
     elif data[5] == "11" and shape == "SHAPE_RECT":
+        if data[11] == 0:  # Check if the hole is oval
+            pass
+        else:
+            drill_size = [drill_size, mil2mm(data[11])]
+
         pad_type = Pad.TYPE_THT
         pad_layer = Pad.LAYERS_THT
 
@@ -208,22 +213,22 @@ def h_ARC(data, kicad_mod, footprint_info):
         midpoint = [end[0] + midX, end[1] + midY]
 
         sq1 = (
-            pow(midpoint[0], 2)
-            + pow(midpoint[1], 2)
-            - pow(start[0], 2)
-            - pow(start[1], 2)
+                pow(midpoint[0], 2)
+                + pow(midpoint[1], 2)
+                - pow(start[0], 2)
+                - pow(start[1], 2)
         )
         sq2 = pow(end[0], 2) + pow(end[1], 2) - pow(start[0], 2) - pow(start[1], 2)
 
         centerX = ((start[1] - end[1]) / (start[1] - midpoint[1]) * sq1 - sq2) / (
-            2 * (start[0] - end[0])
-            - 2
-            * (start[0] - midpoint[0])
-            * (start[1] - end[1])
-            / (start[1] - midpoint[1])
+                2 * (start[0] - end[0])
+                - 2
+                * (start[0] - midpoint[0])
+                * (start[1] - end[1])
+                / (start[1] - midpoint[1])
         )
         centerY = -(2 * (start[0] - midpoint[0]) * centerX + sq1) / (
-            2 * (start[1] - midpoint[1])
+                2 * (start[1] - midpoint[1])
         )
         center = [centerX, centerY]
 
@@ -244,7 +249,7 @@ def h_CIRCLE(data, kicad_mod, footprint_info):
     # append a Circle to the footprint
 
     if (
-        data[4] == "100"
+            data[4] == "100"
     ):  # they want to draw a circle on pads, we don't want that. This is an empirical deduction, no idea if this is correct, but it seems to work on my tests
         return ()
 


### PR DESCRIPTION
Issue: oval pad holes not recognized.
Solution: data[11] seems to carry to the length of the hole

Tested only using C13453 so some more testing required that I didn't have time to do.

Before:
![kicad_2023-01-16_22-25-41](https://user-images.githubusercontent.com/21282105/212769039-2cf29d2c-f3a8-49a0-9844-4f91d46c8014.png)

Same in EasyEDA:
![image](https://user-images.githubusercontent.com/21282105/212768787-20a406dd-b29f-4262-8030-81a932458b77.png)

After:
![image](https://user-images.githubusercontent.com/21282105/212769018-3616d45e-d799-428c-90b0-bb6a1d969019.png)


Also, the connector shape rectangle is drawn filled for some reason. Maybe we need to recognize if the rectangle is filled and use KicadModTree.nodes.specialized.RectLine?

Here is some example data:
Filled:
   ` "RECT~3985.87~2984~28~17~3~gge45~0~0~~~~",`
Not filled:
    `"RECT~3985.87~2984~28~17~3~gge45~0~1~none~~~",`
