### PR TITLE
Added STEP file downloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+JLC2KiCad_lib/

--- a/JLC2KiCadLib/footprint/footprint_handlers.py
+++ b/JLC2KiCadLib/footprint/footprint_handlers.py
@@ -4,7 +4,7 @@ from math import pow, acos, pi
 import re
 
 from KicadModTree import *
-from .model3d import get_3Dmodel
+from .model3d import get_3Dmodel, get_StepModel
 
 __all__ = [
     "handlers",
@@ -351,6 +351,12 @@ def h_SVGNODE(data, kicad_mod, footprint_info):
     except Exception:
         logging.exception("footprint handler, h_SVGNODE : failed to parse json data")
         return ()
+    
+    get_StepModel(
+        component_uuid=data["attrs"]["uuid"],
+        footprint_info=footprint_info,
+    )
+
     c_origin = data["attrs"]["c_origin"].split(",")
     get_3Dmodel(
         component_uuid=data["attrs"]["uuid"],

--- a/JLC2KiCadLib/footprint/model3d.py
+++ b/JLC2KiCadLib/footprint/model3d.py
@@ -9,6 +9,29 @@ wrl_header = """#VRML V2.0 utf8
 #for more info see https://github.com/TousstNicolas/JLC2KICAD_lib
 """
 
+def get_StepModel(
+    component_uuid,
+    footprint_info
+):
+    logging.info(f"Downloading STEP Model ...")
+
+    # `qAxj6KHrDKw4blvCG8QJPs7Y` is a constant in
+    # https://modules.lceda.cn/smt-gl-engine/0.8.22.6032922c/smt-gl-engine.js
+    # and points to the bucket containing the step files.
+
+    response = requests.get(
+        f"https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y/{component_uuid}"
+    )
+    if response.status_code == requests.codes.ok:
+        ensure_footprint_lib_directories(footprint_info)
+        filename = f"{footprint_info.output_dir}/{footprint_info.footprint_lib}/packages3d/{footprint_info.footprint_name}.step"
+        with open(filename, "wb") as f:
+            f.write(response.content)
+    else:
+        logging.error("request error, no Step model found")
+        return ()
+
+
 
 def get_3Dmodel(
     component_uuid,
@@ -150,17 +173,7 @@ Shape{{
     x_middle = (max(x_list) + min(x_list)) / 2
     y_middle = (max(y_list) + min(y_list)) / 2
 
-    if not os.path.exists(
-        f"{footprint_info.output_dir}/{footprint_info.footprint_lib}"
-    ):
-        os.makedirs(f"{footprint_info.output_dir}/{footprint_info.footprint_lib}")
-
-    if not os.path.exists(
-        f"{footprint_info.output_dir}/{footprint_info.footprint_lib}/packages3d"
-    ):
-        os.makedirs(
-            f"{footprint_info.output_dir}/{footprint_info.footprint_lib}/packages3d"
-        )
+    ensure_footprint_lib_directories(footprint_info)
 
     filename = f"{footprint_info.output_dir}/{footprint_info.footprint_lib}/packages3d/{footprint_info.footprint_name}.wrl"
     with open(filename, "w") as f:
@@ -192,3 +205,16 @@ Shape{{
         )
     )
     logging.info(f"added {path_name} to footprint")
+
+def ensure_footprint_lib_directories(footprint_info):
+    if not os.path.exists(
+        f"{footprint_info.output_dir}/{footprint_info.footprint_lib}"
+    ):
+        os.makedirs(f"{footprint_info.output_dir}/{footprint_info.footprint_lib}")
+
+    if not os.path.exists(
+        f"{footprint_info.output_dir}/{footprint_info.footprint_lib}/packages3d"
+    ):
+        os.makedirs(
+            f"{footprint_info.output_dir}/{footprint_info.footprint_lib}/packages3d"
+        )


### PR DESCRIPTION
Added downloading of the STEP file as also requested in #51.

The STEP files are kept in a bucket (https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y), the constant can be found in https://modules.lceda.cn/smt-gl-engine/0.8.22.6032922c/smt-gl-engine.js, which gets loaded in EasyEDA Pro.

The STEP files are convenient when loading the board in CAD programs (FreeCad, for example) and serve as a better base for modification than the WRL files. 