### PR TITLE
Fix example use with JLC2KiCadLib command line

### DIFF
--- a/JLC2KiCadLib/JLC2KiCadLib.py
+++ b/JLC2KiCadLib/JLC2KiCadLib.py
@@ -59,7 +59,7 @@ def add_component(component_id, args):
 def main():
     parser = argparse.ArgumentParser(
         description="take a JLCPCB part # and create the according component's kicad's library",
-        epilog="example use : \n	python3 JLC2KiCad_lib.py C1337258 C24112 -dir My_lib -symbol_lib My_Symbol_lib --no_footprint",
+        epilog="example use : \n	JLC2KiCadLib C1337258 C24112 -dir My_lib -symbol_lib My_Symbol_lib --no_footprint",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ options:
   --version             Print versin number and exit
 
 exemple use : 
-        python3 JLC2KiCad_lib.py C1337258 C24112 -dir My_lib -symbol_lib My_Symbol_lib --no_footprint
+        JLC2KiCadLib C1337258 C24112 -dir My_lib -symbol_lib My_Symbol_lib --no_footprint
 ```
 
 The only required arguments are the JLCPCP_part number (e.g. Cxxxxx)


### PR DESCRIPTION
Hello,

I have very recently discovered your project, awesome job ! 
Following the readme was a bit confusing because you have 2 ways to start your script, using `JLC2KiCadLib` directly and using `python3 JLC2KiCad_lib.py`. 

I think the `python3 JLC2KiCad_lib.py`  was the genuine way of calling your script prior to your packaging refactoring (see 8ff517fba5 ).

Regards,
Adrien M.