### PR TITLE
Handle colon character in component title

### DIFF
--- a/JLC2KiCadLib/symbol/symbol.py
+++ b/JLC2KiCadLib/symbol/symbol.py
@@ -59,6 +59,7 @@ def create_symbol(
             .replace("/", "_")
             .replace(" ", "_")
             .replace(".", "_")
+            .replace(":", "{colon}")
         )
 
         component_types_values = []


### PR DESCRIPTION
Hi,
Great work on this awesome library!

I recently ran into an issue converting LCSC parts with colons in the name (e.g, C2838450). It appears that [KiCad does not allow the colon character in symbol names](https://docs.kicad.org/7.0/en/eeschema/eeschema_symbols_and_libraries.html#:~:text=The%20colon%20character%20(%3A)%20cannot%20be%20used%20in%20library%20nicknames%20or%20symbol%20names%20because%20it%20is%20used%20as%20a%20separator%20between%20nicknames%20and%20symbols.), thus the generated symbol library cannot be imported.

As an experiment, I went into KiCad and created a symbol with the colon character in the title. To my surprise, this seemed to work without any issues. When I inspected the symbol library, I found that KiCad had inserted the text `{colon}` in place of the character.

Thus, I added another operation to replace all occurances of `:` with `{colon}` in the component title. Now, the generated symbol library appears to load as expected.