### PR TITLE
Switch 3D models to relative paths to improve portability

### DIFF
--- a/JLC2KiCadLib/footprint/model3d.py
+++ b/JLC2KiCadLib/footprint/model3d.py
@@ -58,7 +58,7 @@ def get_StepModel(
 
     kicad_mod.append(
         Model(
-            filename=path_name,
+            filename=f"{footprint_info.model_dir}/{footprint_info.footprint_name}.step", # was path_name but relative path improves portability
             at=[translationX, translationY, translationZ],
             rotate=[-float(axis_rotation) for axis_rotation in rotation.split(",")],
         )
@@ -205,7 +205,7 @@ Shape{{
     else:
         kicad_mod.append(
             Model(
-                filename=path_name,
+                filename=f"{footprint_info.model_dir}/{footprint_info.footprint_name}.wrl", # was path_name but relative path improves portability
                 at=[translationX, translationY, translationZ],
                 rotate=[-float(axis_rotation) for axis_rotation in rotation.split(",")],
             )


### PR DESCRIPTION
**Great software!**

This pull request changes only two lines, in order to construct relative paths for both STEP and WRL format 3D models.

This improves portability by ensuring that copied library contents will continue to function.

The use case would be, for example, generating a footprint and 3D model with JLC2KiCad_lib and then copying the resulting model to an existing (eg. project-specific) KiCad library.

Additionally, this ensures that potentially privacy sensitive information such as local paths (which may divulge information such as usernames, dates, project names, etc.) is not accidentally shared.