### PR TITLE
Update footprint.py,change F.Fab text from REF** to ${REFERENCE}

### DIFF
--- a/JLC2KiCadLib/footprint/footprint.py
+++ b/JLC2KiCadLib/footprint/footprint.py
@@ -117,7 +117,7 @@ def create_footprint(
     kicad_mod.append(
         Text(
             type="user",
-            text="REF**",
+            text="${REFERENCE}",
             at=[
                 (footprint_info.min_X + footprint_info.max_X) / 2,
                 footprint_info.max_Y + 4,


### PR DESCRIPTION
As I compared with many official footprint,here we should change text for F.Fab layer from REF** to ${REFERENCE},or it will fail to show proper reference when using addons like board2pdf.