### PR TITLE
Update footprint.py,change REF** to ${REFERENCE} and move the F.Fab text to the center

### DIFF
--- a/JLC2KiCadLib/footprint/footprint.py
+++ b/JLC2KiCadLib/footprint/footprint.py
@@ -117,10 +117,10 @@ def create_footprint(
     kicad_mod.append(
         Text(
             type="user",
-            text="REF**",
+            text="${REFERENCE}",
             at=[
                 (footprint_info.min_X + footprint_info.max_X) / 2,
-                footprint_info.max_Y + 4,
+                 (footprint_info.min_Y + footprint_info.max_Y) / 2,
             ],
             layer="F.Fab",
         )


### PR DESCRIPTION
As I compared with official kicad footprints,this text REF** for F.Fab layer should change to ${REFERENCE},also move to the center of the footprint for better view in most practical cases.
Or it will fail to show the reference properly when using addon like board2pdf.
Take a component U7 from one of my board for example,
When using REF**,the board2pdf results like:
<img width="1152" height="832" alt="wrong" src="https://github.com/user-attachments/assets/25ed5759-eb80-499d-82db-5ade7acb1f17" />

With my PR,it show reference correctly:
<img width="1160" height="1188" alt="correct" src="https://github.com/user-attachments/assets/e4cc01f7-a056-4cad-bb18-22e4f9071574" />
