### PR TITLE
Assign default pin electrical type based on pin name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,216 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/JLC2KiCadLib/symbol/symbol_handlers.py
+++ b/JLC2KiCadLib/symbol/symbol_handlers.py
@@ -123,6 +123,11 @@ def h_P(data, translation, kicad_symbol):
     ]
     """
 
+    if len(data) == 24:  # sometimes, the rotation parameter is not in the list.
+        data.insert(5, "0")
+    elif len(data) == 28:
+        data.insert(1, "0")
+
     if data[1] == "0":
         electrical_type = "passive"
     elif data[1] == "1":
@@ -136,8 +141,17 @@ def h_P(data, translation, kicad_symbol):
     else:
         electrical_type = "unspecified"
 
-    pin_number = data[2]
-    pin_name = data[13]
+    eTypeMap = {
+        "0": "passive",
+        "1": "input",
+        "2": "output",
+        "3": "bidirectional",
+        "4": "power_in",
+    }
+    electrical_type = eTypeMap.get(data[1], "unspecified")
+    
+    pinNumber = data[2]
+    pinName = data[13]
 
     x1 = round(mil2mm(float(data[3]) - translation[0]), 3)
     y1 = round(-mil2mm(float(data[4]) - translation[1]), 3)
@@ -150,9 +164,11 @@ def h_P(data, translation, kicad_symbol):
     }
 
     if electrical_type in ["passive", "unspecified"]:
+        pinNameUpper = pinName.upper():
         for tag, eType in pinTypeMap.items():
-            if tag in pinName.upper():
+            if tag in pinNameUpper:
                 electrical_type = eType
+                break
 
     X = round(mil2mm(float(data[3]) - translation[0]), 3)
     Y = round(-mil2mm(float(data[4]) - translation[1]), 3)

--- a/JLC2KiCadLib/symbol/symbol_handlers.py
+++ b/JLC2KiCadLib/symbol/symbol_handlers.py
@@ -124,7 +124,7 @@ def h_P(data, translation, kicad_symbol):
     """
 
     if data[1] == "0":
-        electrical_type = "unspecified"
+        electrical_type = "passive"
     elif data[1] == "1":
         electrical_type = "input"
     elif data[1] == "2":
@@ -141,6 +141,21 @@ def h_P(data, translation, kicad_symbol):
 
     x1 = round(mil2mm(float(data[3]) - translation[0]), 3)
     y1 = round(-mil2mm(float(data[4]) - translation[1]), 3)
+    pinTypeMap = {
+        "GND": "power_in",
+        "VCC": "power_in",
+        "VDD": "power_in",
+        "VIN": "power_in",
+        "IO": "bidirectional",
+    }
+
+    if electrical_type in ["passive", "unspecified"]:
+        for tag, eType in pinTypeMap.items():
+            if tag in pinName.upper():
+                electrical_type = eType
+
+    X = round(mil2mm(float(data[3]) - translation[0]), 3)
+    Y = round(-mil2mm(float(data[4]) - translation[1]), 3)
 
     rotation = (int(data[5]) + 180) % 360 if data[5] else 180
 

--- a/JLC2KiCadLib/symbol/symbol_handlers.py
+++ b/JLC2KiCadLib/symbol/symbol_handlers.py
@@ -122,12 +122,6 @@ def h_P(data, translation, kicad_symbol):
     25 :
     ]
     """
-
-    if len(data) == 24:  # sometimes, the rotation parameter is not in the list.
-        data.insert(5, "0")
-    elif len(data) == 28:
-        data.insert(1, "0")
-
     eTypeMap = {
         "0": "passive",
         "1": "input",
@@ -142,6 +136,7 @@ def h_P(data, translation, kicad_symbol):
 
     x1 = round(mil2mm(float(data[3]) - translation[0]), 3)
     y1 = round(-mil2mm(float(data[4]) - translation[1]), 3)
+
     pinTypeMap = {
         "GND": "power_in",
         "VCC": "power_in",
@@ -165,9 +160,6 @@ def h_P(data, translation, kicad_symbol):
             if tag in pin_nameUpper:
                 electrical_type = eType
                 break
-
-    X = round(mil2mm(float(data[3]) - translation[0]), 3)
-    Y = round(-mil2mm(float(data[4]) - translation[1]), 3)
 
     rotation = (int(data[5]) + 180) % 360 if data[5] else 180
 

--- a/JLC2KiCadLib/symbol/symbol_handlers.py
+++ b/JLC2KiCadLib/symbol/symbol_handlers.py
@@ -149,7 +149,7 @@ def h_P(data, translation, kicad_symbol):
         "4": "power_in",
     }
     electrical_type = eTypeMap.get(data[1], "unspecified")
-    
+
     pinNumber = data[2]
     pinName = data[13]
 
@@ -173,7 +173,7 @@ def h_P(data, translation, kicad_symbol):
     }
 
     if electrical_type in ["passive", "unspecified"]:
-        pinNameUpper = pinName.upper():
+        pinNameUpper = pinName.upper()
         for tag, eType in pinTypeMap.items():
             if tag in pinNameUpper:
                 electrical_type = eType

--- a/JLC2KiCadLib/symbol/symbol_handlers.py
+++ b/JLC2KiCadLib/symbol/symbol_handlers.py
@@ -128,19 +128,6 @@ def h_P(data, translation, kicad_symbol):
     elif len(data) == 28:
         data.insert(1, "0")
 
-    if data[1] == "0":
-        electrical_type = "passive"
-    elif data[1] == "1":
-        electrical_type = "input"
-    elif data[1] == "2":
-        electrical_type = "output"
-    elif data[1] == "3":
-        electrical_type = "bidirectional"
-    elif data[1] == "4":
-        electrical_type = "power_in"
-    else:
-        electrical_type = "unspecified"
-
     eTypeMap = {
         "0": "passive",
         "1": "input",
@@ -150,8 +137,8 @@ def h_P(data, translation, kicad_symbol):
     }
     electrical_type = eTypeMap.get(data[1], "unspecified")
 
-    pinNumber = data[2]
-    pinName = data[13]
+    pin_number = data[2]
+    pin_name = data[13]
 
     x1 = round(mil2mm(float(data[3]) - translation[0]), 3)
     y1 = round(-mil2mm(float(data[4]) - translation[1]), 3)
@@ -173,9 +160,9 @@ def h_P(data, translation, kicad_symbol):
     }
 
     if electrical_type in ["passive", "unspecified"]:
-        pinNameUpper = pinName.upper()
+        pin_nameUpper = pin_name.upper()
         for tag, eType in pinTypeMap.items():
-            if tag in pinNameUpper:
+            if tag in pin_nameUpper:
                 electrical_type = eType
                 break
 

--- a/JLC2KiCadLib/symbol/symbol_handlers.py
+++ b/JLC2KiCadLib/symbol/symbol_handlers.py
@@ -160,7 +160,16 @@ def h_P(data, translation, kicad_symbol):
         "VCC": "power_in",
         "VDD": "power_in",
         "VIN": "power_in",
+        "3V3": "power_in",
         "IO": "bidirectional",
+        "EN": "input",
+        "NC": "no_connect",
+        "VOUT": "power_out",
+        "OUT": "output",
+        "TX": "output",
+        "RX": "input",
+        "SCL": "unspecified",
+        "SDA": "bidirectional",
     }
 
     if electrical_type in ["passive", "unspecified"]:


### PR DESCRIPTION
When EasyEDA symbols have unspecified pin electrical type 0, in my case found most of them are equivalent to Kicad's "passive". Also, I would manually assign the electrical type to each power input pin like Vcc or Vdd. This modification does that automatically so that the types need still to be reviewed, but the default values could be closer to the actual ones.