### PR TITLE
Fix with incorrect User.Comments Layer Name with Cmts.User

### DIFF
--- a/JLC2KiCadLib/footprint/footprint_handlers.py
+++ b/JLC2KiCadLib/footprint/footprint_handlers.py
@@ -43,11 +43,11 @@ layer_correspondance = {
     "7": "F.Mask",
     "8": "B.Mask",
     "10": "Edge.Cuts",
-    "11": "User.Comments",  # EasyEDA "Multilayer"
+    "11": "Cmts.User",  # EasyEDA "Multilayer"
     "12": "F.Fab",
-    "99": "User.Comments",  # EasyEDA "Component shape layer"
-    "100": "User.Comments",  # EasyEDA "Pin soldering layer"
-    "101": "User.Comments",  # EasyEDA "Component marking layer"
+    "99": "Cmts.User",  # EasyEDA "Component shape layer"
+    "100": "Cmts.User",  # EasyEDA "Pin soldering layer"
+    "101": "Cmts.User",  # EasyEDA "Component marking layer"
 }
 
 


### PR DESCRIPTION
"User.Comments" is a layer name displayed in Footprint Editor,but should be "Cmts.User" inside the kicad_mod file. Refer:
https://gitlab.com/kicad/code/kicad/-/blame/master/common/lset.cpp#L131
https://gitlab.com/kicad/code/kicad/-/blame/master/qa/data/pcbnew/sliver.kicad_pcb#L20

Sorry for previous commit,I've double confirmed this one on my own project.